### PR TITLE
Loosen size restrictions from cashaddr

### DIFF
--- a/reusable_addresses.md
+++ b/reusable_addresses.md
@@ -127,7 +127,7 @@ For a recipient who intends to receive to a p2pkh addresses, encode the followin
 | 33 | scan_pubkey | char | 256-bit compressed ECDSA/Schnorr public key of the recipient used to derive common secret |
 | 33 | spend_pubkey | char | 256-bit compressed ECDSA/Schnorr public key of the recipient used to derive payto addresses when combined with common secret |
 | 4 | expiry | uint32 | UNIX time beyond which the paycode should not be used. 0 for no expiry. Use 0 for versions 1,2,3,4. |
-| 5 | checksum | char | checksum calculated the same way as [Cashaddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#bch). |
+| 5 | checksum | char | checksum calculated in a similar way as [Cashaddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#bch) but without size enforcement regarding the version byte. The version byte scheme from Cashaddr is replaced as above.|
 
 For a recipient who intends to receive to a p2sh-multisig addresses, encode the following in base32 using the same character set as cashaddr:
 
@@ -143,7 +143,7 @@ For a recipient who intends to receive to a p2sh-multisig addresses, encode the 
 | ... | ... | ... | ... |
 | 33 | spend_pubkeyn | char | nth compressed ECDSA/Schnorr public key of the recipients |
 | 4 | expiry | uint32 | UNIX time beyond which the paycode should not be used. 0 for no expiry. Use 0 for versions 1,2,3,4. |
-| 5 | checksum | char | checksum calculated the same way as [Cashaddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#bch). |
+| 5 | checksum | char | checksum calculated in a similar way as [Cashaddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#bch) but without size enforcement regarding the version byte. The version byte scheme from Cashaddr is replaced as above.|
 
 The payment code shall be prefixed with `paycode:`, and can be optionally suffixed with offchain communications networks it supports in URI, e.g. `?xmpp=johndoe@something.org&matrix=@john123:something.com`. If no additional suffix is detected, the default offchain relay method, a necessity for version 2, 4, 6 and 8, is Ephemeral Relay service (see below).
 
@@ -157,7 +157,7 @@ For the easy facilitation of paper wallets and inter-wallet transfers, the scan 
 | 1 | multisig_setup | uint4 + uint4 | instruction on constructing multig m-of-n (see above). 0 on both if P2PKH |
 | 1 | prefix_size | uint8 | length of the filtering prefix desired, 0, 4, 8, 12 or 16 bits for versions 1 through 8 ; 0 if no-filter for full-node or offline-communications. If used, recommend >= 8. |
 | 33 | privkey | char | 256-bit ECDSA/Schnorr private key |
-| 5 | checksum | char | checksum calculated the same way as [Cashaddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#bch). |
+| 5 | checksum | char | checksum calculated in a similar way as [Cashaddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#bch) but without size enforcement regarding the version byte. The version byte scheme from Cashaddr is replaced as above.|
 
 ## Paycode creation from two keypairs (P2PKH) 
 


### PR DESCRIPTION
Cashaddr defined 8 allowed sizes but RPA may exceed the longest. Remove size enforcement at the expense of slightly less strict error checking. 