### PR TITLE
modifications to main derivation sections

### DIFF
--- a/reusable_addresses.md
+++ b/reusable_addresses.md
@@ -2,7 +2,7 @@
 
 BIP-???
 
-v0.4.3, further limit number of inputs
+v0.5.0, changes and clarification on derivation process
 
 @im_uname, with material from Mark Lundeberg, plus discussion with Chris Pacia, Amaury Séchet, Shammah Chancellor, Jonathan Silverblood and Josh Ellithorpe. Additional editing from Freetrader, Emergent_reasons and Jonald Fyookball.
 


### PR DESCRIPTION
This is a consolidation and rewrite of the main sections on prefix / derivation.

- Put emphasis on how recipients must behave, as this is where most complexity exists.
  Senders in turn need to respect this, and it is their responsibility to not generate
  funds-losing transactions.
- Introduce P2SH-multisig key sorting on outputs, to have the generated multisigs appear typical.
- Change how the outpoint is included in the secret derivation (bytestring concatenation instead of
  integer addition, which was incompletely described before).
- Clarify input-prefix computation in its own section; clarify target-prefix extraction from payment code.
- Carefully specify how wallets may classify & analyze input types by scanning the scriptSig alone.
  (this is what EC will do, for instance).